### PR TITLE
Image upload name escaping

### DIFF
--- a/src/main/java/org/cba/rest/util/FileUploader.java
+++ b/src/main/java/org/cba/rest/util/FileUploader.java
@@ -2,14 +2,19 @@ package org.cba.rest.util;
 
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
+import javax.ws.rs.WebApplicationException;
 import java.io.*;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by adam on 27/11/2017.
  */
 public class FileUploader {
     public String uploadFile(InputStream is, FormDataContentDisposition fileDisposition) throws IOException {
-        String fileName = fileDisposition.getFileName();
+        String fileExtension = getFileExtension(fileDisposition);
+        String fileName = new Date().getTime() + "." + fileExtension;
         String location = System.getenv("PROP_IMG_PATH") + fileName;
         File file = new File(location);
         OutputStream os = new FileOutputStream(file);
@@ -21,5 +26,27 @@ public class FileUploader {
         os.close();
         is.close();
         return System.getenv("PROP_IMG_HTTP_PATH") + fileName;
+    }
+
+    private String getFileExtension(FormDataContentDisposition fileDisposition) {
+        String realFileName = fileDisposition.getFileName();
+        String regex = ".*(\\.(jpg|jpeg|png|tiff))";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(realFileName);
+        if (!matcher.find()) {
+            throw new FileTypeNotSupportedException(realFileName);
+        }
+        return matcher.group(2);
+    }
+
+    class FileTypeNotSupportedException extends WebApplicationException {
+        public FileTypeNotSupportedException(String fileName) {
+            super(
+                    "Unsupported file type fo the uploaded file: " +
+                    fileName +
+                    ". The supported file types are: jpg,jpeg,png,tiff",
+                    400
+            );
+        }
     }
 }

--- a/src/test/java/api/LocationTest.java
+++ b/src/test/java/api/LocationTest.java
@@ -50,7 +50,7 @@ public class LocationTest extends FunctionalTest{
                 .body("id", notNullValue())
                 .body("description", equalTo("Great environment"))
                 .body("title", equalTo("Title"))
-                .body("imageUrl", endsWith("download.jpg"))
+                .body("imageUrl", endsWith(".jpg"))
                 .body("latitude", is(60f))
                 .body("longitude", is(10f));
 

--- a/src/test/java/api/RentalTest.java
+++ b/src/test/java/api/RentalTest.java
@@ -67,7 +67,7 @@ public class RentalTest extends FunctionalTest {
                 .body("latitude", equalTo(60f))
                 .body("longitude", equalTo(10f))
                 .body("rating", equalTo(0))
-                .body("imageUrl", endsWith("download.jpg"));
+                .body("imageUrl", endsWith(".jpg"));
 
     }
 


### PR DESCRIPTION
Special characters in file names were causing issues on the server,
so all of the uploaded files are now named as a timestamp and file extensions are also checked.
